### PR TITLE
feat: add ruleOpts to override the default preprocessor rule options

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,9 @@ Custom options passed on pre-processor loader configuration
 - **Default:** `{}`
 
 Custom options passed on [css-loader](https://github.com/webpack-contrib/css-loader) configuration
+
+#### `ruleOpts`
+- **Type:** `{ [key:string]: any }`
+- **Default:** `{}`
+
+Custom options passed on webpack rule configuration

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ const applyRule = (
   cssmodules: boolean | undefined,
   dev: boolean
 ) => {
-  const { preprocessor, cssOpts, loaderOpts } = opts
+  const { preprocessor, cssOpts, loaderOpts, ruleOpts } = opts
 
   const loaderfn = loaders[preprocessor as PreProcessor]
   const loader = loaderfn(loaderOpts)
@@ -105,6 +105,7 @@ const applyRule = (
   return {
     test: tests[preprocessor as PreProcessor],
     use: loader(cssoptions, dev),
+    ...ruleOpts,
   }
 }
 
@@ -113,6 +114,7 @@ export interface CSSPluginOptions {
   cssmodules?: boolean
   loaderOpts?: Opts
   cssOpts?: Opts
+  ruleOpts?: Opts
 }
 
 const defaultOpts: Record<string, any> = {
@@ -120,6 +122,7 @@ const defaultOpts: Record<string, any> = {
   cssmodules: false,
   loadersOpts: {},
   cssOpts: {},
+  ruleOpts: {},
 }
 
 export const css = (opts: CSSPluginOptions = defaultOpts) =>


### PR DESCRIPTION
I would like to be able to change the `test` property of the preprocessor webpack rule or add an `exclude` property. Adding a `ruleOpts` parameter that overrides the default rule object solves my problem.

Example:

```javascript
// doczrc.js
import { css } from 'docz-plugin-css'

export default {
  plugins: [
    // enable CSS Modules when using ".module.scss" file extension
    css({
      preprocessor: 'sass',
      cssmodules: true,
      ruleOpts: {
        test: /\.module\.scss$/,
        exclude: [/node_modules/],
      },
    }),
    // disable CSS Modules when using ".scss" file extension
    css({
      preprocessor: 'sass',
      cssmodules: false,
      ruleOpts: {
        test: /\.scss$/,
        exclude: [/node_modules/, /\.module\.scss$/],
      },
    }),
  ],
}
```