### PR TITLE
Fix SASS example configuration

### DIFF
--- a/examples/css-sass/doczrc.js
+++ b/examples/css-sass/doczrc.js
@@ -1,8 +1,8 @@
 import { css } from 'docz-plugin-css'
 
 export default {
+  title: 'CSS Sass',
   plugins: [
-    title: 'CSS Sass',
     css({
       preprocessor: 'sass',
       cssmodules: true,


### PR DESCRIPTION
I fixed a `doczrs.js` configuration problem. The `title` should be part of the default export instead of the plugin list.