### PR TITLE
fix: css modules not work

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,8 +101,8 @@ const applyRule = (
       importLoaders: 1,
       sourceMap: !dev,
       ...(cssmodules && { getLocalIdent }),
-    },
-    typeof cssmodules === 'boolean' ? { modules: cssmodules } : {}
+      ...(typeof cssmodules === 'boolean' ? { modules: cssmodules } : {})
+    }
   )
 
   return {

--- a/src/typed.d.ts
+++ b/src/typed.d.ts
@@ -1,3 +1,4 @@
 declare module 'optimize-css-assets-webpack-plugin'
 declare module 'mini-css-extract-plugin'
 declare module 'loader-utils'
+declare module 'deepmerge'


### PR DESCRIPTION
1. deep merge only merge two object, the third param is options https://www.npmjs.com/package/deepmerge