### PR TITLE
Added homepage & repository links for the npm page

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,14 @@
   "module": "dist/index.m.js",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",
+  "homepage": "https://docz.site",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/pedronauck/docz-plugin-css.git"
+  },
+  "bugs": {
+    "url": "https://github.com/pedronauck/docz-plugin-css/issues"
+  },
   "files": [
     "dist/",
     "package.json",


### PR DESCRIPTION
It's always useful to be able to navigate to GitHub repository from the npm package website. I added necessary properties to package.json for it to work.

Homepage leads to official docz website. GitHub link links to this repository. There is also direct link to issues.